### PR TITLE
Update SonarQube Scanner GitHub Action to v5.3.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -179,7 +179,7 @@ jobs:
           fi
 
       - name: SonarQube Scan
-        uses: SonarSource/sonarqube-scan-action@v5
+        uses: SonarSource/sonarqube-scan-action@v5.3.1
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: https://sonarcloud.io


### PR DESCRIPTION
Fixing a security vulnerability that was recently discovered in our SonarQube Scanner GitHub Action.
Update your SonarQube Scanner GitHub Action to v5.3.1.