### PR TITLE
build(deps): bump github/codeql-action and docker/scout-action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -722,7 +722,7 @@ jobs:
       # Upload SARIF to GitHub Security
       ######################
       - name: Upload Trivy SARIF to GitHub Security
-        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         if: always()
         with:
           sarif_file: trivy-results.sarif

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -722,7 +722,7 @@ jobs:
       # Upload SARIF to GitHub Security
       ######################
       - name: Upload Trivy SARIF to GitHub Security
-        uses: github/codeql-action/upload-sarif@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5
+        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         if: always()
         with:
           sarif_file: trivy-results.sarif

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -722,7 +722,7 @@ jobs:
       # Upload SARIF to GitHub Security
       ######################
       - name: Upload Trivy SARIF to GitHub Security
-        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/upload-sarif@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5
         if: always()
         with:
           sarif_file: trivy-results.sarif

--- a/.github/workflows/docker-scout.yml
+++ b/.github/workflows/docker-scout.yml
@@ -126,7 +126,7 @@ jobs:
       - name: Docker Scout
         id: docker-scout
         if: ${{ github.event_name == 'pull_request' }}
-        uses: docker/scout-action@2688993af7bafd6ba8c6a74ec652442be91dd82b # v1.23.1
+        uses: docker/scout-action@7c6b6c3f7844478ace1ffd4e7aef649053d1f87d # v1.24.0
         with:
           command: cves,compare
           image: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
## Summary
- Bump github/codeql-action/upload-sarif from 4.37.4 to 4.37.6 (#377, #379, #380)
- Bump docker/scout-action from 1.23.1 to 1.24.0 (#378)

These are dependabot-authored version bumps to GitHub Actions used in CI workflows, already merged into `dev` and now being promoted to `main`.

## Test plan
- [ ] Verify CI checks pass on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)